### PR TITLE
Updates disableWorker Property

### DIFF
--- a/lib/pdf-parse.js
+++ b/lib/pdf-parse.js
@@ -66,7 +66,7 @@ async function PDF(dataBuffer, options) {
 	// Disable workers to avoid yet another cross-origin issue (workers need
 	// the URL of the script to be loaded, and dynamically loading a cross-origin
 	// script does not work).
-	PDFJS.disableWorker = true;
+	PDFJS.PDFJS.disableWorker = true;
 	let doc = await PDFJS.getDocument(dataBuffer);
 	ret.numpages = doc.numPages;
 


### PR DESCRIPTION
`disableWorker` property was being set at the wrong level. Without this change I kept running into `No PDFJS.workerSrc specified` errors, while running via Node.