### PR TITLE
feat: expose password option for encrypted PDFs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,12 @@ export interface Options {
 	verbosityLevel?: 0 | 1 | 5 | undefined;
 	parallelizePages?: boolean | undefined;
 	batchSize?: number | undefined;
+
+	/**
+	 * Password for encrypted PDFs. Forwarded as-is to PDF.js `getDocument({ password })`.
+	 * Ignored when the document is not encrypted.
+	 */
+	password?: string | undefined;
 }
 
 export interface SmartParserOptions {

--- a/lib/SmartPDFParser.js
+++ b/lib/SmartPDFParser.js
@@ -334,6 +334,11 @@ class SmartPDFParser {
 				parseOptions.pagerenderModule = userOptions.pagerenderModule;
 			}
 
+			// Forward password so encrypted PDFs can be analyzed
+			if (userOptions.password) {
+				parseOptions.password = userOptions.password;
+			}
+
 			const quickParse = await PDF(dataBuffer, parseOptions);
 
 			analysis.pages = quickParse.numpages;

--- a/lib/pdf-child.js
+++ b/lib/pdf-child.js
@@ -36,7 +36,7 @@ function render_page(pageData) {
 // Listen for messages from parent
 process.on('message', async (message) => {
 	try {
-		const { dataBuffer, pdfFilePath, startPage, endPage, batchSize, verbosityLevel, pagerenderModule } = message;
+		const { dataBuffer, pdfFilePath, startPage, endPage, batchSize, verbosityLevel, pagerenderModule, password } = message;
 
 		// Load custom render_page function from external module if provided
 		let customRenderPage = render_page; // Default
@@ -74,7 +74,8 @@ process.on('message', async (message) => {
 			data: uint8Array,
 			disableAutoFetch: true,
 			disableStream: true,
-			disableRange: true
+			disableRange: true,
+			password
 		}).promise;
 
 		const pageTexts = [];

--- a/lib/pdf-parse-aggressive.js
+++ b/lib/pdf-parse-aggressive.js
@@ -63,6 +63,7 @@ async function PDFAggressive(dataBuffer, options) {
 	let doc = await PDFJS.getDocument({
 		verbosity: options.verbosityLevel,
 		data: new Uint8Array(dataBuffer),
+		password: options.password,
 	}).promise;
 
 	ret.numpages = doc.numPages;

--- a/lib/pdf-parse-processes.js
+++ b/lib/pdf-parse-processes.js
@@ -72,6 +72,7 @@ async function PDFProcesses(dataBuffer, options) {
 	let doc = await PDFJS.getDocument({
 		verbosity: options.verbosityLevel,
 		data: new Uint8Array(dataBuffer),
+		password: options.password,
 	}).promise;
 
 	ret.numpages = doc.numPages;
@@ -264,7 +265,8 @@ async function processChunksWithChildren(dataBuffer, chunks, options) {
 				endPage: chunk.end,
 				batchSize: options.batchSize,
 				verbosityLevel: options.verbosityLevel,
-				pagerenderModule: options.pagerenderModule // Path to custom render module
+				pagerenderModule: options.pagerenderModule, // Path to custom render module
+				password: options.password
 			};
 
 			if (require('fs').existsSync(tempFile)) {

--- a/lib/pdf-parse-stream.js
+++ b/lib/pdf-parse-stream.js
@@ -62,6 +62,7 @@ async function PDFStream(dataBuffer, options) {
 	let doc = await PDFJS.getDocument({
 		verbosity: options.verbosityLevel,
 		data: new Uint8Array(dataBuffer),
+		password: options.password,
 	}).promise;
 
 	ret.numpages = doc.numPages;

--- a/lib/pdf-parse-workers.js
+++ b/lib/pdf-parse-workers.js
@@ -71,6 +71,7 @@ async function PDFWorkers(dataBuffer, options) {
 	let doc = await PDFJS.getDocument({
 		verbosity: options.verbosityLevel,
 		data: new Uint8Array(dataBuffer),
+		password: options.password,
 	}).promise;
 
 	ret.numpages = doc.numPages;
@@ -160,7 +161,8 @@ async function processChunksWithWorkers(dataBuffer, chunks, options) {
 					endPage: chunk.end,
 					batchSize: options.batchSize,
 					verbosityLevel: options.verbosityLevel,
-					pagerenderModule: options.pagerenderModule // Path to custom render module
+					pagerenderModule: options.pagerenderModule, // Path to custom render module
+					password: options.password
 				},
 				// Resource limits to prevent memory issues
 				resourceLimits: {

--- a/lib/pdf-parse.js
+++ b/lib/pdf-parse.js
@@ -84,6 +84,7 @@ async function PDF(dataBuffer, options) {
 	let doc = await PDFJS.getDocument({
 		verbosity: options.verbosityLevel ?? DEFAULT_OPTIONS.verbosityLevel,
 		data: new Uint8Array(dataBuffer),
+		password: options.password,
 	}).promise;
 
 	ret.numpages = doc.numPages;

--- a/lib/pdf-worker.js
+++ b/lib/pdf-worker.js
@@ -52,7 +52,7 @@ function render_page(pageData) {
 			throw new Error('No workerData received');
 		}
 
-		const { dataBuffer, startPage, endPage, batchSize, verbosityLevel, pagerenderModule } = workerData;
+		const { dataBuffer, startPage, endPage, batchSize, verbosityLevel, pagerenderModule, password } = workerData;
 
 		if (!dataBuffer) {
 			throw new Error('No dataBuffer in workerData');
@@ -101,7 +101,8 @@ function render_page(pageData) {
 			disableStream: true,
 			disableRange: true,
 			// Don't use workers inside workers
-			worker: null
+			worker: null,
+			password
 		}).promise;
 
 		const pageTexts = [];


### PR DESCRIPTION
Forward an optional `password` field from user options through every parser (default, stream, aggressive, workers, processes, SmartPDFParser) to PDF.js `getDocument({ password })`. The option is also serialized into worker thread `workerData` and child process IPC payloads so that multi-thread/multi-process parsers can open encrypted documents.

https://claude.ai/code/session_01MKvx4cJUUrEoWCxeNzLPvi