### PR TITLE
feat: add Markdown output rendering for issue #11

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -201,6 +201,71 @@ export class SmartPDFParser {
 	getStats(): SmartParserStats;
 }
 
+export interface FontStats {
+	/** Most common font size across the sampled pages (body text). */
+	bodySize: number;
+	/** Threshold (>=) above which a line is treated as `# h1`. */
+	h1Size: number;
+	/** Threshold (>=) above which a line is treated as `## h2`. */
+	h2Size: number;
+	/** Threshold (>=) above which a line is treated as `### h3`. */
+	h3Size: number;
+	/** Median vertical distance between consecutive lines of body text. */
+	lineHeight: number;
+}
+
+export interface MarkdownOptions extends Options {
+	/** Number of pages to sample for font statistics (default: 5). */
+	sampleSize?: number;
+	/** Wrap items in `**...**` / `*...*` based on font name (default: true). */
+	detectEmphasis?: boolean;
+	/** Convert leading bullets and numbered prefixes to Markdown lists (default: true). */
+	detectLists?: boolean;
+	/** Wrap monospace runs in fenced code blocks (default: true). */
+	detectCodeBlocks?: boolean;
+}
+
+/**
+ * Parse a PDF and emit Markdown instead of plain text.
+ *
+ * Performs a two-pass analysis: first samples a few pages to build a font-size
+ * histogram (used to infer headings), then parses the document with a renderer
+ * that emits headings, lists, inline emphasis and (optionally) fenced code
+ * blocks. Heuristic-based — works well on text-heavy PDFs, struggles with
+ * tables and complex multi-column layouts (use a vision model for those).
+ *
+ * @param dataBuffer - PDF file buffer
+ * @param options - Markdown rendering options
+ * @returns Promise with `result.text` containing Markdown
+ */
+export function markdown(dataBuffer: Buffer, options?: MarkdownOptions): Promise<Result>;
+
+/**
+ * Drop-in `pagerender` that emits Markdown using only per-page statistics.
+ * Lower quality than `markdown(buffer)` (no document-wide font stats) but
+ * works in single-call contexts and as a `pagerenderModule` for workers.
+ */
+export function markdownRender(pageData: any): Promise<string>;
+
+/**
+ * Build a Markdown `pagerender` bound to pre-computed font statistics.
+ * Useful when calling `pdf(buffer, { pagerender: createMarkdownRenderer(stats) })`
+ * in a custom flow.
+ */
+export function createMarkdownRenderer(stats: FontStats, options?: MarkdownOptions): (pageData: any) => Promise<string>;
+
+/**
+ * Sample the PDF and compute font-size statistics used to drive Markdown
+ * heading detection. Cheap: defaults to 5 evenly-distributed pages.
+ */
+export function collectFontStats(dataBuffer: Buffer, options?: { sampleSize?: number; verbosityLevel?: number; password?: string }): Promise<FontStats>;
+
+/**
+ * Absolute path to the standalone Markdown renderer module, suitable for
+ * passing as `pagerenderModule` to `workers()` / `processes()`.
+ */
+export const markdownRenderModule: string;
+
 /**
  * Funzione principale di parsing (retrocompatibile)
  */

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const PdfAggressive = require('./lib/pdf-parse-aggressive.js');
 const PdfProcesses = require('./lib/pdf-parse-processes.js');
 const PDFWorkers = require('./lib/pdf-parse-workers.js');
 const SmartPDFParser = require('./lib/SmartPDFParser.js');
+const Markdown = require('./lib/markdown-render.js');
 
 module.exports = Pdf;
 module.exports.stream = PdfStream;
@@ -12,6 +13,12 @@ module.exports.aggressive = PdfAggressive;
 module.exports.processes = PdfProcesses;
 module.exports.workers = PDFWorkers;
 module.exports.SmartPDFParser = SmartPDFParser;
+
+module.exports.markdown = Markdown.markdown;
+module.exports.markdownRender = Markdown.markdownRender;
+module.exports.createMarkdownRenderer = Markdown.createMarkdownRenderer;
+module.exports.collectFontStats = Markdown.collectFontStats;
+module.exports.markdownRenderModule = require.resolve('./lib/markdown-render-page.js');
 
 // ES6/TypeScript compatibility
 module.exports.default = Pdf;

--- a/lib/markdown-render-page.js
+++ b/lib/markdown-render-page.js
@@ -1,0 +1,16 @@
+// Standalone shim for use as `pagerenderModule` in worker/process parsers.
+// Provides per-page Markdown rendering without document-wide font stats —
+// quality is lower than `pdf.markdown(buffer)` (which does a two-pass parse)
+// but works in worker_threads / child_process contexts where closures
+// cannot be serialized.
+//
+// Usage:
+//   pdf.workers(buffer, {
+//     pagerenderModule: require.resolve('pdf-parse-new/lib/markdown-render-page')
+//   })
+
+const { markdownRender } = require('./markdown-render.js');
+
+module.exports = markdownRender;
+module.exports.render_page = markdownRender;
+module.exports.default = markdownRender;

--- a/lib/markdown-render.js
+++ b/lib/markdown-render.js
@@ -1,0 +1,289 @@
+const PDFJS = require('./pdf.js/v4.5.136/build/pdf.js');
+const PDF = require('./pdf-parse.js');
+
+const Y_TOLERANCE = 1.0;
+const DEFAULT_SAMPLE_SIZE = 5;
+const TEXT_CONTENT_OPTS = { normalizeWhitespace: true, disableCombineTextItems: false };
+
+const BOLD_RE = /Bold|Black|Heavy|Semibold|Demibold/i;
+const ITALIC_RE = /Italic|Oblique/i;
+const MONO_RE = /Mono|Courier|Consolas|Menlo/i;
+const BULLET_RE = /^\s*([•·▪◦\-\*])\s+(.+)$/;
+const NUMBERED_RE = /^\s*(\d+)[\.\)]\s+(.+)$/;
+
+async function markdown(dataBuffer, options = {}) {
+	const stats = await collectFontStats(dataBuffer, options);
+	const renderer = createMarkdownRenderer(stats, options);
+	return PDF(dataBuffer, { ...options, pagerender: renderer });
+}
+
+async function collectFontStats(dataBuffer, options = {}) {
+	const sampleSize = Number.isFinite(options.sampleSize) ? options.sampleSize : DEFAULT_SAMPLE_SIZE;
+	PDFJS.disableWorker = true;
+	const doc = await PDFJS.getDocument({
+		verbosity: options.verbosityLevel ?? 0,
+		data: new Uint8Array(dataBuffer),
+		password: options.password
+	}).promise;
+
+	const histogram = new Map();
+	const lineDeltas = [];
+	const sampleIndices = pickSampleIndices(doc.numPages, sampleSize);
+
+	for (const idx of sampleIndices) {
+		try {
+			const page = await doc.getPage(idx);
+			const tc = await page.getTextContent(TEXT_CONTENT_OPTS);
+			let lastY;
+			for (const item of tc.items) {
+				if (!item.str) continue;
+				const size = roundSize(Math.abs(item.transform[3]));
+				histogram.set(size, (histogram.get(size) || 0) + item.str.length);
+				const y = item.transform[5];
+				if (lastY !== undefined) {
+					const delta = Math.abs(y - lastY);
+					if (delta > Y_TOLERANCE) lineDeltas.push(delta);
+				}
+				lastY = y;
+			}
+		} catch (_) {
+			// skip pages that fail to render
+		}
+	}
+
+	doc.destroy();
+	return computeFontStats(histogram, lineDeltas);
+}
+
+function createMarkdownRenderer(stats, options = {}) {
+	const renderOpts = {
+		detectEmphasis: options.detectEmphasis !== false,
+		detectLists: options.detectLists !== false,
+		detectCodeBlocks: options.detectCodeBlocks !== false
+	};
+	return async function renderPage(pageData) {
+		const tc = await pageData.getTextContent(TEXT_CONTENT_OPTS);
+		return renderItemsToMarkdown(tc.items, tc.styles || {}, stats, renderOpts);
+	};
+}
+
+async function markdownRender(pageData) {
+	const tc = await pageData.getTextContent(TEXT_CONTENT_OPTS);
+	const stats = computeStatsFromItems(tc.items);
+	return renderItemsToMarkdown(tc.items, tc.styles || {}, stats, {
+		detectEmphasis: true,
+		detectLists: true,
+		detectCodeBlocks: true
+	});
+}
+
+function renderItemsToMarkdown(items, styles, stats, opts) {
+	const lines = groupItemsIntoLines(items);
+	const blocks = [];
+	let codeBuffer = null;
+
+	const flushCode = () => {
+		if (codeBuffer && codeBuffer.length) {
+			blocks.push('```\n' + codeBuffer.join('\n') + '\n```');
+		}
+		codeBuffer = null;
+	};
+
+	for (const line of lines) {
+		const rendered = renderLine(line, styles, stats, opts);
+		if (!rendered) continue;
+
+		if (opts.detectCodeBlocks && rendered.kind === 'code') {
+			if (!codeBuffer) codeBuffer = [];
+			codeBuffer.push(rendered.text);
+			continue;
+		}
+
+		flushCode();
+		blocks.push(rendered.text);
+	}
+	flushCode();
+
+	return blocks.join('\n\n');
+}
+
+function groupItemsIntoLines(items) {
+	const lines = [];
+	let current = null;
+	let lastY;
+	for (const item of items) {
+		if (typeof item.str !== 'string') continue;
+		const y = item.transform[5];
+		const isNewLine = lastY === undefined || Math.abs(y - lastY) > Y_TOLERANCE;
+		if (isNewLine) {
+			if (current) lines.push(current);
+			current = { y, items: [] };
+		}
+		current.items.push(item);
+		lastY = y;
+	}
+	if (current) lines.push(current);
+	return lines;
+}
+
+function renderLine(line, styles, stats, opts) {
+	const rawText = line.items.map(i => i.str).join('').replace(/\s+/g, ' ').trim();
+	if (!rawText) return null;
+
+	const maxSize = Math.max(...line.items.map(i => Math.abs(i.transform[3])));
+	const text = opts.detectEmphasis ? combineLineWithEmphasis(line.items, styles) : rawText;
+
+	if (maxSize >= stats.h1Size) return { kind: 'heading', text: `# ${stripEmphasis(text)}` };
+	if (maxSize >= stats.h2Size) return { kind: 'heading', text: `## ${stripEmphasis(text)}` };
+	if (maxSize >= stats.h3Size) return { kind: 'heading', text: `### ${stripEmphasis(text)}` };
+
+	if (opts.detectLists) {
+		const bullet = rawText.match(BULLET_RE);
+		if (bullet) {
+			const inline = opts.detectEmphasis
+				? combineLineWithEmphasis(line.items, styles).replace(BULLET_RE, '$2')
+				: bullet[2];
+			return { kind: 'list', text: `- ${inline}` };
+		}
+		const numbered = rawText.match(NUMBERED_RE);
+		if (numbered) {
+			const inline = opts.detectEmphasis
+				? combineLineWithEmphasis(line.items, styles).replace(NUMBERED_RE, '$2')
+				: numbered[2];
+			return { kind: 'list', text: `${numbered[1]}. ${inline}` };
+		}
+	}
+
+	if (opts.detectCodeBlocks && isMonospaceLine(line.items, styles)) {
+		return { kind: 'code', text: rawText };
+	}
+
+	return { kind: 'paragraph', text };
+}
+
+function combineLineWithEmphasis(items, styles) {
+	let result = '';
+	let buffer = '';
+	let state = { bold: false, italic: false };
+
+	const flush = () => {
+		if (!buffer) return;
+		const match = buffer.match(/^(\s*)([\s\S]*?)(\s*)$/);
+		const lead = match[1];
+		const core = match[2];
+		const trail = match[3];
+		if (!core) {
+			result += buffer;
+			buffer = '';
+			return;
+		}
+		let wrapped = core;
+		if (state.bold && state.italic) wrapped = `***${wrapped}***`;
+		else if (state.bold) wrapped = `**${wrapped}**`;
+		else if (state.italic) wrapped = `*${wrapped}*`;
+		result += lead + wrapped + trail;
+		buffer = '';
+	};
+
+	for (const item of items) {
+		const fam = (styles[item.fontName] && styles[item.fontName].fontFamily) || item.fontName || '';
+		const bold = BOLD_RE.test(fam);
+		const italic = ITALIC_RE.test(fam);
+		if (bold === state.bold && italic === state.italic) {
+			buffer += item.str;
+		} else {
+			flush();
+			state = { bold, italic };
+			buffer = item.str;
+		}
+	}
+	flush();
+	return result.replace(/\s+/g, ' ').trim();
+}
+
+function isMonospaceLine(items, styles) {
+	if (!items.length) return false;
+	let monoChars = 0;
+	let totalChars = 0;
+	for (const item of items) {
+		const fam = (styles[item.fontName] && styles[item.fontName].fontFamily) || item.fontName || '';
+		const len = item.str.length;
+		totalChars += len;
+		if (MONO_RE.test(fam)) monoChars += len;
+	}
+	return totalChars > 0 && monoChars / totalChars >= 0.7;
+}
+
+function stripEmphasis(text) {
+	return text.replace(/\*\*\*|\*\*|\*/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function pickSampleIndices(total, sampleSize) {
+	if (total <= sampleSize) {
+		return Array.from({ length: total }, (_, i) => i + 1);
+	}
+	const step = total / sampleSize;
+	const indices = new Set();
+	for (let i = 0; i < sampleSize; i++) {
+		const idx = Math.max(1, Math.min(total, Math.round(step * i + step / 2)));
+		indices.add(idx);
+	}
+	return [...indices];
+}
+
+function roundSize(size) {
+	return Math.round(size * 2) / 2;
+}
+
+function computeFontStats(histogram, lineDeltas) {
+	if (histogram.size === 0) {
+		return { bodySize: 12, h1Size: 18, h2Size: 15, h3Size: 13.5, lineHeight: 14.4 };
+	}
+	const entries = [...histogram.entries()];
+	const totalChars = entries.reduce((s, [, c]) => s + c, 0);
+
+	const byCount = [...entries].sort((a, b) => b[1] - a[1]);
+	const bodySize = byCount[0][0];
+
+	const bySize = [...entries].sort((a, b) => b[0] - a[0]);
+	let cumulative = 0;
+	let h1Size = bodySize * 1.6;
+	let h2Size = bodySize * 1.3;
+	let h3Size = bodySize * 1.15;
+	for (const [size, count] of bySize) {
+		if (size <= bodySize * 1.05) break;
+		cumulative += count;
+		const pct = cumulative / totalChars;
+		if (pct <= 0.02) h1Size = Math.min(h1Size, size);
+		if (pct <= 0.06) h2Size = Math.min(h2Size, size);
+		if (pct <= 0.12) h3Size = Math.min(h3Size, size);
+	}
+
+	if (h3Size <= bodySize) h3Size = bodySize * 1.15;
+	if (h2Size <= h3Size) h2Size = h3Size * 1.1;
+	if (h1Size <= h2Size) h1Size = h2Size * 1.1;
+
+	const sortedDeltas = [...lineDeltas].sort((a, b) => a - b);
+	const lineHeight = sortedDeltas.length
+		? sortedDeltas[Math.floor(sortedDeltas.length / 2)]
+		: bodySize * 1.2;
+
+	return { bodySize, h1Size, h2Size, h3Size, lineHeight };
+}
+
+function computeStatsFromItems(items) {
+	const histogram = new Map();
+	for (const it of items) {
+		if (typeof it.str !== 'string' || !it.str) continue;
+		const size = roundSize(Math.abs(it.transform[3]));
+		histogram.set(size, (histogram.get(size) || 0) + it.str.length);
+	}
+	return computeFontStats(histogram, []);
+}
+
+module.exports = {
+	markdown,
+	markdownRender,
+	createMarkdownRenderer,
+	collectFontStats
+};

--- a/test/markdown-default.js
+++ b/test/markdown-default.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const fs = require('fs');
+const pdf = require('../');
+const { collectFontStats, createMarkdownRenderer, markdownRender } = require('../lib/markdown-render.js');
+
+const PDF_FILE = './test/data/01-valid.pdf';
+
+describe('Markdown rendering', function () {
+	this.timeout(30000);
+	const dataBuffer = fs.readFileSync(PDF_FILE);
+
+	it('pdf.markdown() returns a Result with non-empty Markdown text', async function () {
+		const result = await pdf.markdown(dataBuffer);
+		assert.ok(result.text.length > 0, 'expected non-empty text');
+		assert.ok(result.numpages > 0, 'expected numpages > 0');
+		assert.equal(result.numrender, result.numpages);
+	});
+
+	it('plain pdf() output still parses successfully (no regression)', async function () {
+		const plain = await pdf(dataBuffer);
+		assert.ok(plain.text.length > 0);
+		assert.equal(plain.numrender, plain.numpages);
+	});
+
+	it('collectFontStats produces ordered thresholds', async function () {
+		const stats = await collectFontStats(dataBuffer, { sampleSize: 3 });
+		assert.ok(stats.bodySize > 0, 'bodySize must be > 0');
+		assert.ok(stats.h3Size > stats.bodySize, 'h3 must exceed body');
+		assert.ok(stats.h2Size >= stats.h3Size, 'h2 must be >= h3');
+		assert.ok(stats.h1Size >= stats.h2Size, 'h1 must be >= h2');
+		assert.ok(stats.lineHeight > 0, 'lineHeight must be > 0');
+	});
+
+	it('createMarkdownRenderer integrates with pdf() via pagerender option', async function () {
+		const stats = await collectFontStats(dataBuffer, { sampleSize: 3 });
+		const renderer = createMarkdownRenderer(stats);
+		const result = await pdf(dataBuffer, { pagerender: renderer });
+		assert.ok(result.text.length > 0);
+	});
+
+	it('markdownRender works as a single-page drop-in pagerender', async function () {
+		const result = await pdf(dataBuffer, { pagerender: markdownRender });
+		assert.ok(result.text.length > 0);
+	});
+
+	it('markdownRenderModule is a resolvable absolute path', function () {
+		assert.equal(typeof pdf.markdownRenderModule, 'string');
+		assert.ok(pdf.markdownRenderModule.endsWith('markdown-render-page.js'));
+		const loaded = require(pdf.markdownRenderModule);
+		assert.equal(typeof loaded, 'function');
+	});
+});


### PR DESCRIPTION
New helpers exposed from the package root:
- pdf.markdown(buffer, opts)        : two-pass parse → Markdown text
- pdf.markdownRender(pageData)      : drop-in pagerender (single page)
- pdf.createMarkdownRenderer(stats) : build a pagerender from custom stats
- pdf.collectFontStats(buffer)      : sample pages to compute font histogram
- pdf.markdownRenderModule          : path usable as pagerenderModule for
                                      workers/processes

The renderer infers headings from a font-size histogram (h1/h2/h3), detects bullet/numbered lists, wraps inline emphasis in **/* using the font name (Bold/Italic/Oblique markers), and optionally fences monospace runs as code blocks. Tables and complex multi-column layouts are out of scope for v1 — heuristic-only, no vision model fallback.

https://claude.ai/code/session_01MKvx4cJUUrEoWCxeNzLPvi